### PR TITLE
[BUGFIX] Fix composer cms version constrain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0",
   "require": {
-    "typo3/cms": ">=6.2.0 <9.9.99"
+    "typo3/cms": ">=6.2.0,<9.9.99"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
We get an RuntimeException due to misconfiguration in the composer.json

[RuntimeException]
 Could not load package 1stone/fetchurl in https://composer.typo3.org: [UnexpectedValueException] Could not parse version const
 raint >=6.2.0 <9.9.99: Invalid version string "6.2.0 <9.9.99"